### PR TITLE
Support UTF8 in quasiquoted YAML

### DIFF
--- a/groundhog-th/Database/Groundhog/TH.hs
+++ b/groundhog-th/Database/Groundhog/TH.hs
@@ -28,7 +28,7 @@ import Language.Haskell.TH
 import Language.Haskell.TH.Syntax (StrictType, VarStrictType, Lift(..))
 import Language.Haskell.TH.Quote
 import Control.Monad (forM, forM_, when, unless, liftM2)
-import Data.ByteString.Char8 (pack)
+import Data.ByteString.UTF8 (fromString)
 import Data.Char (isUpper, isLower, isSpace, isDigit, toUpper, toLower)
 import Data.Either (lefts)
 import Data.List (nub, (\\))
@@ -521,7 +521,7 @@ groundhogFile = quoteFile groundhog
 
 parseDefinitions :: String -> Q Exp
 parseDefinitions s = do
-  result <- runIO $ decodeHelper (Y.decode $ pack s)
+  result <- runIO $ decodeHelper (Y.decode $ fromString s)
   case result of
     Left err -> case err of
       InvalidYaml (Just (Y.YamlParseException problem context mark)) -> fail $ unlines

--- a/groundhog-th/groundhog-th.cabal
+++ b/groundhog-th/groundhog-th.cabal
@@ -19,6 +19,7 @@ library
                    , time                     >= 1.1.4
                    , containers               >= 0.2
                    , yaml                     >= 0.8.1
+                   , utf8-string              >= 0.3       && < 0.4
     exposed-modules: Database.Groundhog.TH
                      Database.Groundhog.TH.Settings
                      Database.Groundhog.TH.CodeGen


### PR DESCRIPTION
Hi!  This tiny patch enables the Groundhog quasiquoter to work with (some?) Haskell and database identifiers that contain non-ASCII characters.  The quasiquoter input is assumed to be UTF-8.

I’ve only tested this with rather simple names using accented latin characters like «á», and it works for both Haskell and doublequoted PostgreSQL identifiers.
