### PR TITLE
groundhog needs GHC >= 7.4 due to ConstraintKinds usage

### DIFF
--- a/groundhog/groundhog.cabal
+++ b/groundhog/groundhog.cabal
@@ -16,7 +16,7 @@ extra-source-files:
     changelog
 
 library
-    build-depends:   base                     >= 4          && < 5
+    build-depends:   base                     >= 4.5        && < 5
                    , bytestring               >= 0.9
                    , base64-bytestring
                    , transformers             >= 0.2.1      && < 0.5


### PR DESCRIPTION
```
Database/Groundhog/Core.hs:1:190:
    Unsupported extension: ConstraintKinds
```

I'll revise existing versions so a new release isn't necessary.
