### PR TITLE
Restrict lower bound of `bytestring`

### DIFF
--- a/groundhog/groundhog.cabal
+++ b/groundhog/groundhog.cabal
@@ -17,7 +17,7 @@ extra-source-files:
 
 library
     build-depends:   base                     >= 4.5        && < 5
-                   , bytestring               >= 0.9
+                   , bytestring               >= 0.10
                    , base64-bytestring
                    , transformers             >= 0.2.1      && < 0.5
                    , mtl                      >= 2.0


### PR DESCRIPTION
This avoids the compile error below:

```
Configuring groundhog-0.7.0.3...
Building groundhog-0.7.0.3...
Preprocessing library groundhog-0.7.0.3...
[1 of 9] Compiling Database.Groundhog.Core ( Database/Groundhog/Core.hs, dist/dist-sandbox-2e12d3f8/build/Database/Groundhog/Core.o )
[2 of 9] Compiling Database.Groundhog.Generic ( Database/Groundhog/Generic.hs, dist/dist-sandbox-2e12d3f8/build/Database/Groundhog/Generic.o )
[3 of 9] Compiling Database.Groundhog.Instances ( Database/Groundhog/Instances.hs, dist/dist-sandbox-2e12d3f8/build/Database/Groundhog/Instances.o )

Database/Groundhog/Instances.hs:133:53:
    Not in scope: `Lazy.toStrict'

Database/Groundhog/Instances.hs:134:55:
    Not in scope: `Lazy.fromStrict'

Database/Groundhog/Instances.hs:135:35:
    Not in scope: `Lazy.fromStrict'
cabal: Error: some packages failed to install:
groundhog-0.7.0.3 failed during the building phase. The exception was:
```