### PR TITLE
Improved basic example

### DIFF
--- a/examples/README-basic.md
+++ b/examples/README-basic.md
@@ -1,0 +1,38 @@
+# Groundhog basic example
+
+This code is a simple, commented example of the
+use of the
+`[groundhog](https://github.com/lykahb/groundhog)`
+Record-Relational Model (RRM) database interface for
+Haskell.  The example creates a couple of customers and has
+them purchase products from a notional store.
+
+By default, data is "persisted" in an in-memory SQLite3
+database that disappears on program exit. You may choose one
+of several other options as an argument when running the
+program:
+
+* `sqlite`: Creates the database as "example.sqlite3" in the
+  current directory.
+
+* `mysql`: Connects to a MySQL server on the default port as
+  user `test` and uses the database `groundhog_example`.
+  This database must have been pre-created and permissions
+  given to the test user.
+  
+* `postgresql`: Connects to a PostgresQL server on the
+  default port as user `test` and uses the database
+  `groundhog_example`.  This database must have been
+  pre-created and permissions given to the test user.
+
+The `mysql` and `postgresql` options are configurable by
+environment variables:
+
+* `GROUNDHOG\_EXAMPLE\_USERNAME`: Selects test user name.
+* `GROUNDHOG\_EXAMPLE\_DATABASE`: Selects test database name.
+* `GROUNDHOG\_EXAMPLE\_PASSWORD`: Supplies a password for the test user.
+
+For the databases that actually persist, all rows of the
+tables are deleted at the start of each run. This allows
+post-run inspection of the database, but prevents
+accumulation of users and products.

--- a/examples/README-multidb.md
+++ b/examples/README-multidb.md
@@ -1,11 +1,11 @@
-# Groundhog basic example
+# Groundhog multidb example
 
 This code is a simple, commented example of the
 use of the
 `[groundhog](https://github.com/lykahb/groundhog)`
 Record-Relational Model (RRM) database interface for
-Haskell.  The example creates a couple of customers and has
-them purchase products from a notional store.
+Haskell.  The example shows the use of any one of a number
+of database backends.
 
 By default, data is "persisted" in an in-memory SQLite3
 database that disappears on program exit. You may choose one

--- a/examples/basic.hs
+++ b/examples/basic.hs
@@ -1,105 +1,30 @@
 {-# LANGUAGE GADTs, TypeFamilies, TemplateHaskell,
-             QuasiQuotes, FlexibleInstances, FlexibleContexts,
-             StandaloneDeriving #-}
-               
+             QuasiQuotes, FlexibleInstances #-}
+
 -- Toy example of groundhog use.
 
-import Control.Monad.IO.Class (liftIO, MonadIO)
+import Control.Monad.IO.Class (liftIO)
 import Database.Groundhog.Sqlite
-import Database.Groundhog.MySQL
-import Database.Groundhog.Postgresql
 import Database.Groundhog.TH
-import System.Environment
 
 data Customer = Customer {
       customerName :: String,
       phone :: String
     } deriving Show
 
-data Product = Product {
-      productName :: String,
-      quantity :: Int,
-      customer :: DefaultKey Customer
-    }
-
--- The standalone deriving is to get customer handled correctly.
-deriving instance Show Product
-
 -- The schema description is written in Template Haskell.
 -- It describes which records are to be persisted,
 -- and any other desired peculiarities of the database.
 mkPersist defaultCodegenConfig [groundhog|
 - entity: Customer               # Name of the datatype
-  constructors:
-    - name: Customer
-      fields:
-        - name: customerName
-          # Set column name to "name" instead of "customerName"
-          dbName: name
-- entity: Product
 |]
 
--- Convenience function for environment lookup.
-getDefaultedEnv :: String -> String -> IO String
-getDefaultedEnv envName defaultValue = do
-  let lookupName = "GROUNDHOG_EXAMPLE_" ++ envName
-  envValue <- lookupEnv lookupName
-  case envValue of
-    Nothing -> return defaultValue
-    Just value -> return value
+-- The example manipulates some customer records.
+main :: IO ()
+main = withSqliteConn ":memory:" $ runDbConn $ do
 
--- Default default username.
-defaultUsername :: String
-defaultUsername = "test"
-
--- Default default password.
-defaultDatabase :: String
-defaultDatabase = "groundhog_example"
-
-getConnInfo :: IO (String, String, String)
-getConnInfo = do
-  username <- getDefaultedEnv "USERNAME" defaultUsername
-  database <- getDefaultedEnv "DATABASE" defaultDatabase
-  password <- getDefaultedEnv "PASSWORD" ""
-  return (username, database, password)
-
--- Connection information for MySQL is kind of complicated.
-makeMySQLConnInfo :: IO ConnectInfo
-makeMySQLConnInfo = do
-  (username, database, password) <- getConnInfo
-  return $ ConnectInfo {
-                      connectHost = "localhost",
-                      connectPort = 3306,
-                      connectUser = username,
-                      connectPassword = password,
-                      connectDatabase = database,
-                      connectOptions = [],
-                      connectPath = "",
-                      connectSSL = Nothing
-                    }
-
--- Connection information for Postgresql is string-formatted.
-makePostgresqlConnInfo :: IO String
-makePostgresqlConnInfo = do
-  (username, database, password) <- getConnInfo
-  return $
-    "host=localhost port=5432 user=" ++ username ++
-    " dbname=" ++ database ++ applyPassword password
-  where
-    applyPassword "" = ""
-    applyPassword pw = " password=" ++ pw
-
--- The actual example simulates some purchases from an online store.
-example :: (PersistBackend m, SqlDb (PhantomDb m), MonadIO m) => m ()
-example = do
-  -- Create database and tables as needed.
-  runMigration $ do
-    migrate (undefined :: Customer)
-    migrate (undefined :: Product)
-
-  -- Toy example, so drop any previous state.
-  deleteAll (undefined :: Product)
-  deleteAll (undefined :: Customer)
+  -- Create database and table as needed.
+  runMigration $ migrate (undefined :: Customer)
 
   -- Stick a customer into the database.
   johnKey <- insert $ Customer "John Doe" "0123456789"
@@ -108,10 +33,6 @@ example = do
   johnRecord <- get johnKey
   liftIO $ print johnRecord
 
-  -- Have our customer buy some stuff.
-  _ <- insert $ Product "Apples" 5 johnKey
-  _ <- insert $ Product "Melon" 3 johnKey
-
   -- Insert another customer.
   janeKey <- insert $ Customer "Jane Doe" "987654321"
 
@@ -119,36 +40,4 @@ example = do
   -- in this case, everybody.
   allCustomers <- select CondEmpty
   liftIO $ putStrLn $
-             "All customers: " ++ show (allCustomers :: [Customer])
-
-  -- Have our new customer buy some stuff.
-  _ <- insert $ Product "Oranges" 4 janeKey
-
-  -- Bonus melon for all large melon orders. The values
-  -- used in expressions should have known type, so
-  -- literal 5 is annotated.
-  update [QuantityField =. liftExpr QuantityField + 1]
-             (ProductNameField ==. "Melon" &&. QuantityField >. (5 :: Int))
-
-  -- Get and show first customer's order sorted by product name.
-  productsForJohn <-
-      select $ (CustomerField ==. johnKey) `orderBy` [Asc ProductNameField]
-  liftIO $ putStrLn $ "Products for John: " ++ show productsForJohn
-
--- Sample driver.
-main :: IO ()
-main = do
-  -- We will be database-independent, because we can.
-  db <- getArgs
-  case db of
-    [] ->
-        withSqliteConn ":memory:" $ runDbConn $ example
-    ["sqlite"] ->
-        withSqliteConn "example.sqlite3" $ runDbConn $ example
-    ["mysql"] -> do
-            mySQLConnInfo <- makeMySQLConnInfo
-            withMySQLConn mySQLConnInfo $ runDbConn $ example
-    ["postgresql"] -> do
-            pgQLConnInfo <- makePostgresqlConnInfo
-            withPostgresqlConn pgQLConnInfo $ runDbConn $ example
-    _ -> error "unknown database"
+    "All customers: " ++ show (allCustomers :: [Customer])

--- a/examples/basic.hs
+++ b/examples/basic.hs
@@ -1,35 +1,154 @@
-{-# LANGUAGE GADTs, TypeFamilies, TemplateHaskell, QuasiQuotes, FlexibleInstances, StandaloneDeriving #-}
-import Control.Monad.IO.Class (liftIO)
-import Database.Groundhog.TH
-import Database.Groundhog.Sqlite
+{-# LANGUAGE GADTs, TypeFamilies, TemplateHaskell,
+             QuasiQuotes, FlexibleInstances, FlexibleContexts,
+             StandaloneDeriving #-}
+               
+-- Toy example of groundhog use.
 
-data Customer = Customer {customerName :: String, phone :: String} deriving Show
-data Product = Product {productName :: String, quantity :: Int, customer :: DefaultKey Customer}
+import Control.Monad.IO.Class (liftIO, MonadIO)
+import Database.Groundhog.Sqlite
+import Database.Groundhog.MySQL
+import Database.Groundhog.Postgresql
+import Database.Groundhog.TH
+import System.Environment
+
+data Customer = Customer {
+      customerName :: String,
+      phone :: String
+    } deriving Show
+
+data Product = Product {
+      productName :: String,
+      quantity :: Int,
+      customer :: DefaultKey Customer
+    }
+
+-- The standalone deriving is to get customer handled correctly.
 deriving instance Show Product
 
+-- The schema description is written in Template Haskell.
+-- It describes which records are to be persisted,
+-- and any other desired peculiarities of the database.
 mkPersist defaultCodegenConfig [groundhog|
 - entity: Customer               # Name of the datatype
   constructors:
     - name: Customer
       fields:
         - name: customerName
-          dbName: name           # Set column name to "name" instead of "customerName"
+          # Set column name to "name" instead of "customerName"
+          dbName: name
 - entity: Product
 |]
 
-main = withSqliteConn ":memory:" $ runDbConn $ do
+-- Convenience function for environment lookup.
+getDefaultedEnv :: String -> String -> IO String
+getDefaultedEnv envName defaultValue = do
+  let lookupName = "GROUNDHOG_EXAMPLE_" ++ envName
+  envValue <- lookupEnv lookupName
+  case envValue of
+    Nothing -> return defaultValue
+    Just value -> return value
+
+-- Default default username.
+defaultUsername :: String
+defaultUsername = "test"
+
+-- Default default password.
+defaultDatabase :: String
+defaultDatabase = "groundhog_example"
+
+getConnInfo :: IO (String, String, String)
+getConnInfo = do
+  username <- getDefaultedEnv "USERNAME" defaultUsername
+  database <- getDefaultedEnv "DATABASE" defaultDatabase
+  password <- getDefaultedEnv "PASSWORD" ""
+  return (username, database, password)
+
+-- Connection information for MySQL is kind of complicated.
+makeMySQLConnInfo :: IO ConnectInfo
+makeMySQLConnInfo = do
+  (username, database, password) <- getConnInfo
+  return $ ConnectInfo {
+                      connectHost = "localhost",
+                      connectPort = 3306,
+                      connectUser = username,
+                      connectPassword = password,
+                      connectDatabase = database,
+                      connectOptions = [],
+                      connectPath = "",
+                      connectSSL = Nothing
+                    }
+
+-- Connection information for Postgresql is string-formatted.
+makePostgresqlConnInfo :: IO String
+makePostgresqlConnInfo = do
+  (username, database, password) <- getConnInfo
+  return $
+    "host=localhost port=5432 user=" ++ username ++
+    " dbname=" ++ database ++ applyPassword password
+  where
+    applyPassword "" = ""
+    applyPassword pw = " password=" ++ pw
+
+-- The actual example simulates some purchases from an online store.
+example :: (PersistBackend m, SqlDb (PhantomDb m), MonadIO m) => m ()
+example = do
+  -- Create database and tables as needed.
   runMigration $ do
     migrate (undefined :: Customer)
     migrate (undefined :: Product)
+
+  -- Toy example, so drop any previous state.
+  deleteAll (undefined :: Product)
+  deleteAll (undefined :: Customer)
+
+  -- Stick a customer into the database.
   johnKey <- insert $ Customer "John Doe" "0123456789"
-  get johnKey >>= liftIO . print
-  insert $ Product "Apples" 5 johnKey
-  insert $ Product "Melon" 3 johnKey
+
+  -- Get our customer back out and show him.
+  johnRecord <- get johnKey
+  liftIO $ print johnRecord
+
+  -- Have our customer buy some stuff.
+  _ <- insert $ Product "Apples" 5 johnKey
+  _ <- insert $ Product "Melon" 3 johnKey
+
+  -- Insert another customer.
   janeKey <- insert $ Customer "Jane Doe" "987654321"
+
+  -- Find and list all customers matching a particular select:
+  -- in this case, everybody.
   allCustomers <- select CondEmpty
-  liftIO $ putStrLn $ "All customers: " ++ show (allCustomers :: [Customer])
-  insert $ Product "Oranges" 4 janeKey
-  -- bonus melon for all large melon orders. The values used in expressions should have known type, so literal 5 is annotated.
-  update [QuantityField =. liftExpr QuantityField + 1] (ProductNameField ==. "Melon" &&. QuantityField >. (5 :: Int))
-  productsForJohn <- select $ (CustomerField ==. johnKey) `orderBy` [Asc ProductNameField]
+  liftIO $ putStrLn $
+             "All customers: " ++ show (allCustomers :: [Customer])
+
+  -- Have our new customer buy some stuff.
+  _ <- insert $ Product "Oranges" 4 janeKey
+
+  -- Bonus melon for all large melon orders. The values
+  -- used in expressions should have known type, so
+  -- literal 5 is annotated.
+  update [QuantityField =. liftExpr QuantityField + 1]
+             (ProductNameField ==. "Melon" &&. QuantityField >. (5 :: Int))
+
+  -- Get and show first customer's order sorted by product name.
+  productsForJohn <-
+      select $ (CustomerField ==. johnKey) `orderBy` [Asc ProductNameField]
   liftIO $ putStrLn $ "Products for John: " ++ show productsForJohn
+
+-- Sample driver.
+main :: IO ()
+main = do
+  -- We will be database-independent, because we can.
+  db <- getArgs
+  case db of
+    [] ->
+        withSqliteConn ":memory:" $ runDbConn $ example
+    ["sqlite"] ->
+        withSqliteConn "example.sqlite3" $ runDbConn $ example
+    ["mysql"] -> do
+            mySQLConnInfo <- makeMySQLConnInfo
+            withMySQLConn mySQLConnInfo $ runDbConn $ example
+    ["postgresql"] -> do
+            pgQLConnInfo <- makePostgresqlConnInfo
+            withPostgresqlConn pgQLConnInfo $ runDbConn $ example
+    _ -> error "unknown database"

--- a/examples/dbSpecificTypes.hs
+++ b/examples/dbSpecificTypes.hs
@@ -10,9 +10,9 @@ data Point = Point { pointX :: Int, pointY :: Int } deriving Show
 
 -- PostgreSQL keeps point in format "(x,y)". This instance relies on the correspondence between Haskell tuple format and PostgreSQL point format.
 instance PrimitivePersistField Point where
-  toPrimitivePersistValue _ (Point x y) = PersistString $ show (x, y)
-  fromPrimitivePersistValue _ (PersistString a) = let (x, y) = read a in Point x y
-  fromPrimitivePersistValue _ (PersistByteString a) = let (x, y) = read (unpack a) in Point x y
+  toPrimitivePersistValue p (Point x y) = toPrimitivePersistValue p $ show (x, y)
+  fromPrimitivePersistValue p a = Point x y where
+    (x, y) = read $ fromPrimitivePersistValue p a
 
 instance PersistField Point where
   persistName _ = "Point"

--- a/examples/groundhog-examples.cabal
+++ b/examples/groundhog-examples.cabal
@@ -23,6 +23,8 @@ executable basic
                      , transformers
                      , groundhog-th
                      , groundhog-sqlite
+                     , groundhog-mysql
+                     , groundhog-postgresql
 
   default-language:    Haskell2010
 

--- a/examples/groundhog-examples.cabal
+++ b/examples/groundhog-examples.cabal
@@ -23,6 +23,26 @@ executable basic
                      , transformers
                      , groundhog-th
                      , groundhog-sqlite
+
+  default-language:    Haskell2010
+
+executable tables
+  main-is:             tables.hs
+  build-depends:       base >=4 && <5
+                     , groundhog
+                     , transformers
+                     , groundhog-th
+                     , groundhog-sqlite
+
+  default-language:    Haskell2010
+
+executable multidb
+  main-is:             multidb.hs
+  build-depends:       base >=4 && <5
+                     , groundhog
+                     , transformers
+                     , groundhog-th
+                     , groundhog-sqlite
                      , groundhog-mysql
                      , groundhog-postgresql
 

--- a/examples/multidb.hs
+++ b/examples/multidb.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE GADTs, TypeFamilies, TemplateHaskell,
+             QuasiQuotes, FlexibleInstances, FlexibleContexts #-}
+               
+-- Example of groundhog runnable against any of several
+-- databases, showing handling of their connections.
+
+import Control.Monad.IO.Class (liftIO, MonadIO)
+import Database.Groundhog.Sqlite
+import Database.Groundhog.MySQL
+import Database.Groundhog.Postgresql
+import Database.Groundhog.TH
+import System.Environment
+
+data Customer = Customer {
+      customerName :: String,
+      phone :: String
+    } deriving Show
+
+-- The schema description is written in Template Haskell.
+-- It describes which records are to be persisted,
+-- and any other desired peculiarities of the database.
+mkPersist defaultCodegenConfig [groundhog|
+- entity: Customer               # Name of the datatype
+|]
+
+-- Convenience function for environment lookup.
+getDefaultedEnv :: String -> String -> IO String
+getDefaultedEnv envName defaultValue = do
+  let lookupName = "GROUNDHOG_EXAMPLE_" ++ envName
+  envValue <- lookupEnv lookupName
+  case envValue of
+    Nothing -> return defaultValue
+    Just value -> return value
+
+-- Default default username.
+defaultUsername :: String
+defaultUsername = "test"
+
+-- Default default password.
+defaultDatabase :: String
+defaultDatabase = "groundhog_example"
+
+getConnInfo :: IO (String, String, String)
+getConnInfo = do
+  username <- getDefaultedEnv "USERNAME" defaultUsername
+  database <- getDefaultedEnv "DATABASE" defaultDatabase
+  password <- getDefaultedEnv "PASSWORD" ""
+  return (username, database, password)
+
+-- Connection information for MySQL is kind of complicated.
+makeMySQLConnInfo :: IO ConnectInfo
+makeMySQLConnInfo = do
+  (username, database, password) <- getConnInfo
+  return $ ConnectInfo {
+                      connectHost = "localhost",
+                      connectPort = 3306,
+                      connectUser = username,
+                      connectPassword = password,
+                      connectDatabase = database,
+                      connectOptions = [],
+                      connectPath = "",
+                      connectSSL = Nothing
+                    }
+
+-- Connection information for Postgresql is string-formatted.
+makePostgresqlConnInfo :: IO String
+makePostgresqlConnInfo = do
+  (username, database, password) <- getConnInfo
+  return $
+    "host=localhost port=5432 user=" ++ username ++
+    " dbname=" ++ database ++ applyPassword password
+  where
+    applyPassword "" = ""
+    applyPassword pw = " password=" ++ pw
+
+
+-- The actual example simulates some purchases from an online store.
+example :: (PersistBackend m, SqlDb (PhantomDb m), MonadIO m) => m ()
+example = do
+
+  -- Create database and table as needed.
+  runMigration $ migrate (undefined :: Customer)
+
+  -- Toy example, so throw away any old customer records
+  -- to prevent them piling up in persistent databases.
+  deleteAll (undefined :: Customer)
+
+  -- Stick a customer into the database.
+  johnKey <- insert $ Customer "John Doe" "0123456789"
+
+  -- Get our customer back out and show him.
+  johnRecord <- get johnKey
+  liftIO $ print johnRecord
+
+  -- Insert another customer.
+  janeKey <- insert $ Customer "Jane Doe" "987654321"
+
+  -- Find and list all customers matching a particular select:
+  -- in this case, everybody.
+  allCustomers <- select CondEmpty
+  liftIO $ putStrLn $
+    "All customers: " ++ show (allCustomers :: [Customer])
+
+
+-- Sample driver.
+main :: IO ()
+main = do
+  -- We will be database-independent, because we can.
+  db <- getArgs
+  case db of
+    [] ->
+        withSqliteConn ":memory:" $ runDbConn $ example
+    ["sqlite"] ->
+        withSqliteConn "example.sqlite3" $ runDbConn $ example
+    ["mysql"] -> do
+            mySQLConnInfo <- makeMySQLConnInfo
+            withMySQLConn mySQLConnInfo $ runDbConn $ example
+    ["postgresql"] -> do
+            pgQLConnInfo <- makePostgresqlConnInfo
+            withPostgresqlConn pgQLConnInfo $ runDbConn $ example
+    _ -> error "unknown database"

--- a/examples/tables.hs
+++ b/examples/tables.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE GADTs, TypeFamilies, TemplateHaskell,
+             QuasiQuotes, FlexibleInstances,
+             StandaloneDeriving #-}
+               
+-- Example of groundhog use with multiple connected tables.
+
+import Control.Monad.IO.Class (liftIO)
+import Database.Groundhog.Sqlite
+import Database.Groundhog.TH
+
+data Customer = Customer {
+      customerName :: String,
+      phone :: String
+    } deriving Show
+
+data Product = Product {
+      productName :: String,
+      quantity :: Int,
+      customer :: DefaultKey Customer
+    }
+
+-- The standalone deriving is to get customer handled correctly.
+deriving instance Show Product
+
+-- The schema description is written in Template Haskell.
+-- It describes which records are to be persisted,
+-- and any other desired peculiarities of the database.
+mkPersist defaultCodegenConfig [groundhog|
+- entity: Customer               # Name of the datatype
+  constructors:
+    - name: Customer
+      fields:
+        - name: customerName
+          # Set column name to "name" instead of "customerName"
+          dbName: name
+- entity: Product
+|]
+
+-- The example simulates some purchases from an online store.
+main :: IO ()
+main = withSqliteConn ":memory:" $ runDbConn $ do
+
+  -- Create database and tables as needed.
+  runMigration $ do
+    migrate (undefined :: Customer)
+    migrate (undefined :: Product)
+
+  -- Stick a customer into the database.
+  johnKey <- insert $ Customer "John Doe" "0123456789"
+
+  -- Get our customer back out and show him.
+  johnRecord <- get johnKey
+  liftIO $ print johnRecord
+
+  -- Have our customer buy some stuff.
+  _ <- insert $ Product "Apples" 5 johnKey
+  _ <- insert $ Product "Melon" 3 johnKey
+
+  -- Insert another customer.
+  janeKey <- insert $ Customer "Jane Doe" "987654321"
+
+  -- Find and list all customers matching a particular select:
+  -- in this case, everybody.
+  allCustomers <- select CondEmpty
+  liftIO $ putStrLn $
+             "All customers: " ++ show (allCustomers :: [Customer])
+
+  -- Have our new customer buy some stuff.
+  _ <- insert $ Product "Oranges" 4 janeKey
+
+  -- Bonus melon for all large melon orders. The values
+  -- used in expressions should have known type, so
+  -- literal 5 is annotated.
+  update [QuantityField =. liftExpr QuantityField + 1]
+             (ProductNameField ==. "Melon" &&. QuantityField >. (5 :: Int))
+
+  -- Get and show first customer's order sorted by product name.
+  productsForJohn <-
+      select $ (CustomerField ==. johnKey) `orderBy` [Asc ProductNameField]
+  liftIO $ putStrLn $ "Products for John: " ++ show productsForJohn

--- a/groundhog-mysql/Database/Groundhog/MySQL.hs
+++ b/groundhog-mysql/Database/Groundhog/MySQL.hs
@@ -607,6 +607,7 @@ newtype P = P PersistValue
 
 instance MySQL.Param P where
   render (P (PersistString t))      = MySQL.render t
+  render (P (PersistText t))        = MySQL.render t
   render (P (PersistByteString bs)) = MySQL.render bs
   render (P (PersistInt64 i))       = MySQL.render i
   render (P (PersistDouble d))      = MySQL.render d
@@ -654,8 +655,8 @@ getGetter MySQLBase.Year       = convertPV PersistDay
 -- Null
 getGetter MySQLBase.Null       = \_ _ -> PersistNull
 -- Controversial conversions
-getGetter MySQLBase.Set        = convertPV PersistString
-getGetter MySQLBase.Enum       = convertPV PersistString
+getGetter MySQLBase.Set        = convertPV PersistText
+getGetter MySQLBase.Enum       = convertPV PersistText
 -- Unsupported
 getGetter other = error $ "MySQL.getGetter: type " ++
                   show other ++ " not supported."

--- a/groundhog-pipes/Database/Groundhog/Pipes.hs
+++ b/groundhog-pipes/Database/Groundhog/Pipes.hs
@@ -38,7 +38,9 @@ fromStream stream = do
         case a of
           Just a' -> yield a' >> go
           Nothing -> return ()
-  go `finally` (maybe (return ()) liftIO close)
+  case close of
+    Nothing -> go
+    Just close' -> go `finally` liftIO close'
 
 selectStream :: (PersistBackend m, MonadSafe m, PersistEntity v, EntityConstr v c, HasSelectOptions opts (Conn m) (RestrictionHolder v c))
              => opts

--- a/groundhog-postgresql/Database/Groundhog/Postgresql.hs
+++ b/groundhog-postgresql/Database/Groundhog/Postgresql.hs
@@ -744,6 +744,7 @@ newtype P = P PersistValue
 
 instance PGTF.ToField P where
   toField (P (PersistString t))         = PGTF.toField t
+  toField (P (PersistText t))           = PGTF.toField t
   toField (P (PersistByteString bs))    = PGTF.toField (PG.Binary bs)
   toField (P (PersistInt64 i))          = PGTF.toField i
   toField (P (PersistDouble d))         = PGTF.toField d
@@ -764,19 +765,19 @@ getGetter :: PG.Oid -> Getter PersistValue
 getGetter (PG.Oid oid) = case oid of
   16   -> convertPV PersistBool
   17   -> convertPV (PersistByteString . unBinary)
-  18   -> convertPV PersistString
-  19   -> convertPV PersistString
+  18   -> convertPV PersistText
+  19   -> convertPV PersistText
   20   -> convertPV PersistInt64
   21   -> convertPV PersistInt64
   23   -> convertPV PersistInt64
-  25   -> convertPV PersistString
-  142  -> convertPV PersistString
+  25   -> convertPV PersistText
+  142  -> convertPV PersistText
   700  -> convertPV PersistDouble
   701  -> convertPV PersistDouble
   702  -> convertPV PersistUTCTime
   703  -> convertPV PersistUTCTime
-  1042 -> convertPV PersistString
-  1043 -> convertPV PersistString
+  1042 -> convertPV PersistText
+  1043 -> convertPV PersistText
   1082 -> convertPV PersistDay
   1083 -> convertPV PersistTimeOfDay
   1114 -> convertPV (PersistUTCTime . localTimeToUTC utc)

--- a/groundhog-postgresql/Database/Groundhog/Postgresql/Geometry.hs
+++ b/groundhog-postgresql/Database/Groundhog/Postgresql/Geometry.hs
@@ -73,7 +73,7 @@ points :: Parser [Point]
 points = point `sepBy1` char ','
 
 instance PrimitivePersistField Point where
-  toPrimitivePersistValue _ (Point x y) = PersistString $ show (x, y)
+  toPrimitivePersistValue p (Point x y) = toPrimitivePersistValue p $ show (x, y)
   fromPrimitivePersistValue _ = parseHelper point
 
 instance PersistField Point where
@@ -83,7 +83,7 @@ instance PersistField Point where
   dbType _ _ = DbTypePrimitive (DbOther $ OtherTypeDef $ [Left "point"]) False Nothing Nothing
 
 instance PrimitivePersistField Line where
-  toPrimitivePersistValue _ (Line (Point x1 y1) (Point x2 y2)) = PersistString $ show ((x1, y1), (x2, y2))
+  toPrimitivePersistValue p (Line (Point x1 y1) (Point x2 y2)) = toPrimitivePersistValue p $ show ((x1, y1), (x2, y2))
   fromPrimitivePersistValue _ = error "fromPrimitivePersistValue Line is not supported yet"
 
 instance PersistField Line where
@@ -93,7 +93,7 @@ instance PersistField Line where
   dbType _ _ = DbTypePrimitive (DbOther $ OtherTypeDef $ [Left "line"]) False Nothing Nothing
 
 instance PrimitivePersistField Lseg where
-  toPrimitivePersistValue _ (Lseg (Point x1 y1) (Point x2 y2)) = PersistString $ show ((x1, y1), (x2, y2))
+  toPrimitivePersistValue p (Lseg (Point x1 y1) (Point x2 y2)) = toPrimitivePersistValue p $ show ((x1, y1), (x2, y2))
   fromPrimitivePersistValue _ = parseHelper $ pair Lseg '[' ']' point
 
 instance PersistField Lseg where
@@ -103,7 +103,7 @@ instance PersistField Lseg where
   dbType _ _ = DbTypePrimitive (DbOther $ OtherTypeDef $ [Left "lseg"]) False Nothing Nothing
 
 instance PrimitivePersistField Box where
-  toPrimitivePersistValue _ (Box (Point x1 y1) (Point x2 y2)) = PersistString $ show ((x1, y1), (x2, y2))
+  toPrimitivePersistValue p (Box (Point x1 y1) (Point x2 y2)) = toPrimitivePersistValue p $ show ((x1, y1), (x2, y2))
   fromPrimitivePersistValue _ = parseHelper $ Box <$> (point <* char ',') <*> point
 
 instance PersistField Box where
@@ -123,7 +123,7 @@ showPoint :: Point -> ShowS
 showPoint (Point x y) = shows (x, y)
 
 instance PrimitivePersistField Path where
-  toPrimitivePersistValue _ path = PersistString $ case path of
+  toPrimitivePersistValue p path = toPrimitivePersistValue p $ case path of
     ClosedPath ps -> showPath '(' ')' ps ""
     OpenPath ps -> showPath '[' ']' ps ""
   fromPrimitivePersistValue _ = parseHelper $ path' ClosedPath '(' ')' <|> path' OpenPath '[' ']' where
@@ -136,7 +136,7 @@ instance PersistField Path where
   dbType _ _ = DbTypePrimitive (DbOther $ OtherTypeDef $ [Left "path"]) False Nothing Nothing
 
 instance PrimitivePersistField Polygon where
-  toPrimitivePersistValue _ (Polygon ps) = PersistString $ showPath '(' ')' ps ""
+  toPrimitivePersistValue p (Polygon ps) = toPrimitivePersistValue p $ showPath '(' ')' ps ""
   fromPrimitivePersistValue _ = parseHelper $ Polygon <$> (char '(' *> points <* char ')')
 
 instance PersistField Polygon where
@@ -146,7 +146,7 @@ instance PersistField Polygon where
   dbType _ _ = DbTypePrimitive (DbOther $ OtherTypeDef $ [Left "polygon"]) False Nothing Nothing
 
 instance PrimitivePersistField Circle where
-  toPrimitivePersistValue _ (Circle (Point x1 y1) r) = PersistString $ show ((x1, y1), r)
+  toPrimitivePersistValue p (Circle (Point x1 y1) r) = toPrimitivePersistValue p $ show ((x1, y1), r)
   fromPrimitivePersistValue _ = parseHelper $ Circle <$> (char '<' *> point) <* char ',' <*> double <* char '>'
 
 instance PersistField Circle where

--- a/groundhog-sqlite/Database/Groundhog/Sqlite.hs
+++ b/groundhog-sqlite/Database/Groundhog/Sqlite.hs
@@ -445,6 +445,7 @@ bind stmt = go 1 where
   go i (x:xs) = do
     case x of
       PersistInt64 int64      -> S.bindInt64 stmt i int64
+      PersistText text        -> S.bindText stmt i $ text
       PersistString text      -> S.bindText stmt i $ T.pack text
       PersistDouble double    -> S.bindDouble stmt i double
       PersistBool b           -> S.bindInt64 stmt i $ if b then 1 else 0
@@ -493,7 +494,7 @@ queryRawCached' query vals = getStatementCached query >>= \stmt -> queryStmt stm
 pFromSql :: S.SQLData -> PersistValue
 pFromSql (S.SQLInteger i) = PersistInt64 i
 pFromSql (S.SQLFloat i)   = PersistDouble i
-pFromSql (S.SQLText s)    = PersistString (T.unpack s)
+pFromSql (S.SQLText s)    = PersistText s
 pFromSql (S.SQLBlob bs)   = PersistByteString bs
 pFromSql (S.SQLNull)      = PersistNull
 

--- a/groundhog/Database/Groundhog/Core.hs
+++ b/groundhog/Database/Groundhog/Core.hs
@@ -100,6 +100,7 @@ import Control.Monad.Reader (MonadReader(..))
 import Data.ByteString.Char8 (ByteString)
 import Data.Int (Int64)
 import Data.Map (Map)
+import Data.Text (Text)
 import Data.Time (Day, TimeOfDay, UTCTime)
 import Data.Time.LocalTime (ZonedTime, zonedTimeToUTC, zonedTimeToLocalTime, zonedTimeZone)
 import GHC.Exts (Constraint)
@@ -476,6 +477,7 @@ fromUtf8 (Utf8 a) = toByteString a
 -- | A raw value which can be stored in any backend and can be marshalled to
 -- and from a 'PersistField'.
 data PersistValue = PersistString String
+                  | PersistText Text
                   | PersistByteString ByteString
                   | PersistInt64 Int64
                   | PersistDouble Double

--- a/groundhog/Database/Groundhog/Generic/Sql.hs
+++ b/groundhog/Database/Groundhog/Generic/Sql.hs
@@ -238,6 +238,7 @@ renderChain RenderConfig{..} (f, prefix) acc = (case prefix of
 
 defaultShowPrim :: PersistValue -> String
 defaultShowPrim (PersistString x) = "'" ++ x ++ "'"
+defaultShowPrim (PersistText x) = "'" ++ show x ++ "'"
 defaultShowPrim (PersistByteString x) = "'" ++ show x ++ "'"
 defaultShowPrim (PersistInt64 x) = show x
 defaultShowPrim (PersistDouble x) = show x


### PR DESCRIPTION
Thanks much for `groundhog`. It is quite nice.

I found the basic example a bit hard to use and follow. Also, none of the examples answered my question about how to work with `MySQL` instead of in-memory `SQLite`.

Thus, I cleaned up and commented the basic example. I also added support for multiple databases (in-memory SQLite3, persistent SQLite3, MySQL, PostgresQL). I added a README describing operation.
