### PR TITLE
Initial support for GHC 8.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .idea
 .cabal-sandbox/
 cabal.sandbox.config
+.stack-work/

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,13 @@ services:
 matrix:
   include:
   # ghc-7.8.4
-  - env: ARGS="--resolver lts-2"
+  - env: STACK_YAML="stack-ghc-7.8.yaml"
   # ghc-7.10.3
-  - env: ARGS="--resolver lts-6"
+  - env: STACK_YAML="stack-ghc-7.10.yaml"
   # ghc-ghc-8.0.2
-  - env: ARGS="--resolver lts-8"
+  - env: STACK_YAML="stack-ghc-8.0.yaml"
+  # ghc-ghc-8.2
+  - env: STACK_YAML="stack-ghc-8.2.yaml"
 
 before_install:
 # Download and unpack the stack executable
@@ -41,4 +43,4 @@ before_script:
 # executables, and test suites, and runs the test suites. --no-terminal works
 # around some quirks in Travis's terminal implementation.
 script:
-- stack test $ARGS --no-terminal --install-ghc --flag groundhog-test:mysql --flag groundhog-test:postgresql --flag groundhog-test:sqlite
+- stack test --no-terminal --install-ghc --flag groundhog-test:mysql --flag groundhog-test:postgresql --flag groundhog-test:sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,12 @@ matrix:
   - env: STACK_YAML="stack-ghc-7.8.yaml"
   # ghc-7.10.3
   - env: STACK_YAML="stack-ghc-7.10.yaml"
-  # ghc-ghc-8.0.2
+  # ghc-8.0.2
   - env: STACK_YAML="stack-ghc-8.0.yaml"
-  # ghc-ghc-8.2
+  # ghc-8.2.2
   - env: STACK_YAML="stack-ghc-8.2.yaml"
+  # ghc-8.4.3
+  - env: STACK_YAML="stack-ghc-8.4.yaml"
 
 before_install:
 # Download and unpack the stack executable

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_script:
 - cd groundhog-test/
 - psql --username=postgres --file=init_postgresql.sql
 - mysql --user=root < init_mysql.sql
+- cd ..
 
 # This line does all of the work: installs GHC if necessary, build the library,
 # executables, and test suites, and runs the test suites. --no-terminal works

--- a/groundhog-mysql/Database/Groundhog/MySQL.hs
+++ b/groundhog-mysql/Database/Groundhog/MySQL.hs
@@ -47,7 +47,7 @@ import Data.Int (Int64)
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.List (groupBy, intercalate, intersect, isInfixOf, partition, stripPrefix)
 import Data.Maybe (fromJust, fromMaybe, isJust)
-import Data.Monoid
+import Data.Monoid hiding ((<>))
 import Data.Pool
 
 newtype MySQL = MySQL MySQL.Connection

--- a/groundhog-postgresql/Database/Groundhog/Postgresql.hs
+++ b/groundhog-postgresql/Database/Groundhog/Postgresql.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables, FlexibleInstances, FlexibleContexts, OverloadedStrings, TypeFamilies, MultiParamTypeClasses, TemplateHaskell #-}
+
 module Database.Groundhog.Postgresql
     ( withPostgresqlPool
     , withPostgresqlConn
@@ -48,9 +49,13 @@ import Data.Int (Int64)
 import Data.IORef
 import Data.List (groupBy, intercalate, isPrefixOf, stripPrefix)
 import Data.Maybe (fromJust, fromMaybe, isJust, mapMaybe)
-import Data.Monoid
+import Data.Monoid hiding ((<>))
 import Data.Pool
 import Data.Time.LocalTime (localTimeToUTC, utc)
+
+-- work around for no Semigroup instance og PG.Query prior to
+-- postgresql-simple 0.5.3.0
+import qualified Data.ByteString as B
 
 -- typical operations for connection: OPEN, BEGIN, COMMIT, ROLLBACK, CLOSE
 newtype Postgresql = Postgresql PG.Connection
@@ -148,12 +153,24 @@ createPostgresqlPool :: MonadIO m
                      -> m (Pool Postgresql)
 createPostgresqlPool s connCount = liftIO $ createPool (open' s) close' 1 20 connCount
 
+-- Not sure of the best way to handle Semigroup/Monoid changes in ghc 8.4
+-- here. It appears that the long SQL query text interferes with the use
+-- of CPP here.
+--
+-- Manually copying over https://github.com/lpsmith/postgresql-simple/commit/44c0bb8dec3b71e8daefe104cf643c0c4fb26768#diff-75d19972de474bc8fa181e4733f3f0d6R94
+-- but this is not really a good idea.
+--
+combine :: PG.Query -> PG.Query -> PG.Query
+-- combine = (<>)
+combine (PG.Query a) (PG.Query b) = PG.Query (B.append a b)
+
+
 instance Savepoint Postgresql where
   withConnSavepoint name m (Postgresql c) = do
     let name' = fromString name
-    liftIO $ PG.execute_ c $ "SAVEPOINT " <> name'
-    x <- onException m (liftIO $ PG.execute_ c $ "ROLLBACK TO SAVEPOINT " <> name')
-    liftIO $ PG.execute_ c $ "RELEASE SAVEPOINT" <> name'
+    liftIO $ PG.execute_ c $ "SAVEPOINT " `combine` name'
+    x <- onException m (liftIO $ PG.execute_ c $ "ROLLBACK TO SAVEPOINT " `combine` name')
+    liftIO $ PG.execute_ c $ "RELEASE SAVEPOINT" `combine` name'
     return x
 
 instance ConnectionManager Postgresql where

--- a/groundhog-postgresql/Database/Groundhog/Postgresql.hs
+++ b/groundhog-postgresql/Database/Groundhog/Postgresql.hs
@@ -53,7 +53,7 @@ import Data.Monoid hiding ((<>))
 import Data.Pool
 import Data.Time.LocalTime (localTimeToUTC, utc)
 
--- work around for no Semigroup instance og PG.Query prior to
+-- work around for no Semigroup instance of PG.Query prior to
 -- postgresql-simple 0.5.3.0
 import qualified Data.ByteString as B
 

--- a/groundhog-postgresql/Database/Groundhog/Postgresql/Array.hs
+++ b/groundhog-postgresql/Database/Groundhog/Postgresql/Array.hs
@@ -40,7 +40,7 @@ import qualified Data.Attoparsec.Zepto as Z
 import Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Unsafe as B
-import Data.Monoid
+import Data.Monoid hiding ((<>))
 import Data.Word
 import qualified Data.Vector as V
 import Data.Traversable (traverse)

--- a/groundhog-postgresql/groundhog-postgresql.cabal
+++ b/groundhog-postgresql/groundhog-postgresql.cabal
@@ -35,7 +35,7 @@ library
 
     -- See https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid#Writingcompatiblecode
     if !impl(ghc >= 8.0)
-      build-depends: semigroups == 0.18.*
+      build-depends: semigroups
 
     exposed-modules: Database.Groundhog.Postgresql
                      Database.Groundhog.Postgresql.Array

--- a/groundhog-postgresql/groundhog-postgresql.cabal
+++ b/groundhog-postgresql/groundhog-postgresql.cabal
@@ -32,6 +32,11 @@ library
                    , time                     >= 1.1
                    , vector                   >= 0.10     && < 0.13
                    , resourcet                >= 1.1.2
+
+    -- See https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid#Writingcompatiblecode
+    if !impl(ghc >= 8.0)
+      build-depends: semigroups == 0.18.*
+
     exposed-modules: Database.Groundhog.Postgresql
                      Database.Groundhog.Postgresql.Array
                      Database.Groundhog.Postgresql.Geometry

--- a/groundhog-sqlite/Database/Groundhog/Sqlite.hs
+++ b/groundhog-sqlite/Database/Groundhog/Sqlite.hs
@@ -37,7 +37,7 @@ import Data.List (groupBy, intercalate, isInfixOf, partition, sort)
 import Data.IORef
 import qualified Data.HashMap.Strict as Map
 import Data.Maybe (fromMaybe)
-import Data.Monoid
+import Data.Monoid hiding ((<>))
 import Data.Pool
 import qualified Data.Text as T
 

--- a/groundhog-test/groundhog-test.cabal
+++ b/groundhog-test/groundhog-test.cabal
@@ -60,6 +60,9 @@ test-suite test
                  , transformers-compat      >= 0.3
                  , exceptions
 
+    if !impl(ghc >= 8.0)
+      build-depends: semigroups == 0.18.*
+
     hs-source-dirs: ., ../groundhog, ../groundhog-th, ../groundhog-sqlite, ../groundhog-postgresql, ../groundhog-mysql
 
     ghc-options:   -Wall

--- a/groundhog-test/groundhog-test.cabal
+++ b/groundhog-test/groundhog-test.cabal
@@ -61,7 +61,7 @@ test-suite test
                  , exceptions
 
     if !impl(ghc >= 8.0)
-      build-depends: semigroups == 0.18.*
+      build-depends: semigroups
 
     hs-source-dirs: ., ../groundhog, ../groundhog-th, ../groundhog-sqlite, ../groundhog-postgresql, ../groundhog-mysql
 

--- a/groundhog/Database/Groundhog/Generic/PersistBackendHelpers.hs
+++ b/groundhog/Database/Groundhog/Generic/PersistBackendHelpers.hs
@@ -32,7 +32,7 @@ import Database.Groundhog.Generic.Sql
 import Control.Monad (liftM)
 import Data.Either (rights)
 import Data.Maybe (catMaybes, fromJust, mapMaybe)
-import Data.Monoid
+import Data.Monoid hiding ((<>))
 
 get :: forall conn v . (PersistBackendConn conn, PersistEntity v, PrimitivePersistField (Key v BackendSpecific))
     => RenderConfig -> (Utf8 -> [PersistValue] -> Action conn (RowStream [PersistValue])) -> Key v BackendSpecific -> Action conn (Maybe v)

--- a/groundhog/Database/Groundhog/Generic/Sql.hs
+++ b/groundhog/Database/Groundhog/Generic/Sql.hs
@@ -45,7 +45,7 @@ import Database.Groundhog.Instances ()
 import qualified Blaze.ByteString.Builder.Char.Utf8 as B
 import Data.Maybe (mapMaybe, maybeToList)
 #if !(MIN_VERSION_base(4,8,0))
-import Data.Monoid
+import Data.Monoid hiding ((<>))
 #endif
 import Data.String
 

--- a/groundhog/groundhog.cabal
+++ b/groundhog/groundhog.cabal
@@ -36,7 +36,7 @@ library
 
     -- See https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid#Writingcompatiblecode
     if !impl(ghc >= 8.0)
-      build-depends: semigroups == 0.18.*
+      build-depends: semigroups
 
     exposed-modules: Database.Groundhog
                      Database.Groundhog.Core

--- a/groundhog/groundhog.cabal
+++ b/groundhog/groundhog.cabal
@@ -33,6 +33,11 @@ library
                    , resourcet                >= 1.1.2
                    , safe-exceptions
                    , transformers-compat      >= 0.3
+
+    -- See https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid#Writingcompatiblecode
+    if !impl(ghc >= 8.0)
+      build-depends: semigroups == 0.18.*
+
     exposed-modules: Database.Groundhog
                      Database.Groundhog.Core
                      Database.Groundhog.Expression

--- a/stack-ghc-7.10.yaml
+++ b/stack-ghc-7.10.yaml
@@ -12,5 +12,6 @@ packages:
 - groundhog-sqlite/
 - groundhog-th/
 - groundhog-test/
-extra-deps: []
-resolver: lts-12.0
+extra-deps:
+- aeson-pretty-0.8.7
+resolver: lts-6.35

--- a/stack-ghc-7.8.yaml
+++ b/stack-ghc-7.8.yaml
@@ -13,8 +13,12 @@ packages:
 - groundhog-th/
 - groundhog-test/
 extra-deps:
-- aeson-pretty-0.8.7
+- aeson-pretty-0.8.6
 - base-compat-0.10.4
 - safe-exceptions-0.1.7.0
-- semigroups-0.18.5
+- semigroups-0.16.2.2
+# had trouble getting a build solution with newer versions of semigroups
+# - semigroups-0.17.0.1
+# - semigroups-0.18.1
+# - semigroups-0.18.5
 resolver: lts-2.22

--- a/stack-ghc-7.8.yaml
+++ b/stack-ghc-7.8.yaml
@@ -1,0 +1,20 @@
+flags:
+  groundhog-test:
+    mysql: true
+    sqlite: true
+    postgresql: true
+extra-package-dbs: []
+packages:
+- groundhog/
+- examples/
+- groundhog-inspector/
+- groundhog-postgresql/
+- groundhog-sqlite/
+- groundhog-th/
+- groundhog-test/
+extra-deps:
+- aeson-pretty-0.8.7
+- base-compat-0.10.4
+- safe-exceptions-0.1.7.0
+- semigroups-0.18.5
+resolver: lts-2.22

--- a/stack-ghc-8.0.yaml
+++ b/stack-ghc-8.0.yaml
@@ -13,4 +13,4 @@ packages:
 - groundhog-th/
 - groundhog-test/
 extra-deps: []
-resolver: lts-12.0
+resolver: lts-9.21

--- a/stack-ghc-8.2.yaml
+++ b/stack-ghc-8.2.yaml
@@ -13,4 +13,4 @@ packages:
 - groundhog-th/
 - groundhog-test/
 extra-deps: []
-resolver: lts-12.0
+resolver: lts-11.17

--- a/stack-ghc-8.4.yaml
+++ b/stack-ghc-8.4.yaml
@@ -1,0 +1,16 @@
+flags:
+  groundhog-test:
+    mysql: true
+    sqlite: true
+    postgresql: true
+extra-package-dbs: []
+packages:
+- groundhog/
+- examples/
+- groundhog-inspector/
+- groundhog-postgresql/
+- groundhog-sqlite/
+- groundhog-th/
+- groundhog-test/
+extra-deps: []
+resolver: lts-12.0


### PR DESCRIPTION
Add support for GHC 8.4.

I have tweaked the test system (using separate stack.yaml files for each LTS) rather than the "supply the resolver on the command-line" approach, since this was easier for me to deal with the changes to the "extra packages" needed with older LTS versions.

I am not happy about the needed postgresql change, as it essentially copies over the Semigroup/Monoid change made to postgresql-simple - see https://github.com/lpsmith/postgresql-simple/commit/44c0bb8dec3b71e8daefe104cf643c0c4fb26768#diff-75d19972de474bc8fa181e4733f3f0d6R94 - and I would hope there's a better solution. I applied the same solution to MySQL.

If this is an acceptable solution I can rebase this patchset to clean up the commit history.