### PR TITLE
Bump postgresql-simple bounds

### DIFF
--- a/groundhog-postgresql/groundhog-postgresql.cabal
+++ b/groundhog-postgresql/groundhog-postgresql.cabal
@@ -17,7 +17,7 @@ extra-source-files:
 library
     build-depends:   base                     >= 4         && < 5
                    , aeson                    >= 0.8
-                   , postgresql-simple        >= 0.3       && < 0.6
+                   , postgresql-simple        >= 0.3       && < 0.7
                    , postgresql-libpq         >= 0.6.1
                    , bytestring               >= 0.9
                    , blaze-builder            >= 0.3       && < 0.5


### PR DESCRIPTION
I verified that this compiles, but I've been having trouble running the test suite locally 😞 .

This should unblock `groundhog-postgresql` from the latest Stackage nightlies though, which now use `postgresql-simple-0.6`.