### PR TITLE
Add cabal.project to support cabal 3.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,11 @@
+packages:
+  ./examples/
+  ./groundhog/
+  ./groundhog-inspector/
+  ./groundhog-postgresql/
+  ./groundhog-sqlite/
+  ./groundhog-th/
+  ./groundhog-test/
+
+constraints:
+  groundhog-test +mysql +sqlite +postgresql


### PR DESCRIPTION
Makes it easier for cabal users to run tests and build the executable from the top-folder.
Moreover, makes it possible to open `groundhog` in Haskell-IDE-Engine and ghcide with cabal.