### PR TITLE
Changing the order to operations

### DIFF
--- a/groundhog/Database/Groundhog/Generic/Migration.hs
+++ b/groundhog/Database/Groundhog/Generic/Migration.hs
@@ -314,13 +314,13 @@ getAlters m@MigrationPack {..} (TableInfo oldColumns oldUniques oldRefs) (TableI
     colAlters = mapMaybe (\(a, b) -> mkAlterColumn b $ migrateColumn m a b) (filter ((`notElem` primaryColumns) . colName . fst) commonColumns)
     mkAlterColumn col alters = if null alters then Nothing else Just $ AlterColumn col alters
     tableAlters =
-      map (DropColumn . colName) oldOnlyColumns
+      map dropUnique oldOnlyUniques
+        ++ map (DropReference . fromMaybe (error "getAlters: old reference does not have name") . fst) oldOnlyRefs
+        ++ map (DropColumn . colName) oldOnlyColumns
         ++ map AddColumn newOnlyColumns
         ++ colAlters
-        ++ map dropUnique oldOnlyUniques
         ++ map AddUnique newOnlyUniques
         ++ concatMap (uncurry migrateUniq) commonUniques
-        ++ map (DropReference . fromMaybe (error "getAlters: old reference does not have name") . fst) oldOnlyRefs
         ++ map (AddReference . snd) newOnlyRefs
 
 -- from database, from datatype


### PR DESCRIPTION
When column gets deleted (at least in Postgres), database engine also deletes related constraints. Which confuses grouched migration machinery as it is unable to delete absent constraints. I saw two possibilities to fix the issue:
- add `if exists` modifier to the `drop constraint` statement.
- change the order of operations upon migration to delete `old` constraints before dropping the column.

The latter is better, because it doesn't require database support to be idempotent.